### PR TITLE
slack-sdk 3.36.0 

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,0 +1,2 @@
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation --ignore-installed
+if errorlevel 1 exit 1

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,2 +1,0 @@
-%PYTHON% -m pip install . -vv --no-deps --no-build-isolation --ignore-installed
-if errorlevel 1 exit 1

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation --ignore-installed

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-$PYTHON -m pip install . -vv --no-deps --no-build-isolation --ignore-installed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "slack_sdk" %}
+{% set name = "slack-sdk" %}
 {% set version = "3.36.0" %}
 
 package:
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: 8586022bdbdf9f8f8d32f394540436c53b1e7c8da9d21e1eab4560ba70cfcffa
 
 build:
@@ -14,7 +14,7 @@ build:
   skip: True  # [py<36]
 
 outputs:
-  - name: {{ name }}
+  - name: slack-sdk
     script: build_base.bat  # [win]
     script: build_base.sh  # [not win]
     requirements:
@@ -52,7 +52,7 @@ outputs:
         {% set ignore_tests = " --ignore=tests/test_proxy_env_variable_loader.py" %}
         - pytest -v {{ ignore_tests }} tests
 
-  - name: slack-sdk
+  - name: slack_sdk
     requirements:
       host:
         - python
@@ -68,7 +68,7 @@ outputs:
         - pip
       commands:
         - pip check
-        - python -c "from importlib.metadata import version; assert(version('{{ name|replace('_', '-') }}')=='{{ version }}')"        
+        - python -c "from importlib.metadata import version; assert(version('{{ name.replace('-', '_') }}')=='{{ version }}')"
 
 about:
   home: https://slack.dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,61 +11,45 @@ source:
 
 build:
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<36]
 
-outputs:
-  - name: slack-sdk
-    script: build_base.bat  # [win]
-    script: build_base.sh   # [not win]
-    requirements:
-      host:
-        - pip
-        - python
-        - setuptools
-        - wheel
-      run:
-        - python
-    test:
-      source_files:
-        - tests
-      imports:
-        - slack_sdk
-        - slack_sdk.web
-        - slack_sdk.webhook
-        - slack_sdk.signature
-        - slack_sdk.socket_mode
-        - slack_sdk.audit_logs
-        - slack_sdk.scim
-        - slack_sdk.oauth
-        - slack_sdk.models
-        - slack_sdk.rtm
-        - slack_sdk.rtm_v2
-      requires:
-        - pip
-        - pytest
-        # The old RTM API (slack_sdk.rtm) has a dependency on aiohttp
-        - aiohttp >=3.7.3,<4
-      commands:
-        - pip check
-        - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-        - pytest tests
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+  run:
+    - python
+    # The old RTM API (slack_sdk.rtm) has a dependency on aiohttp
+    - aiohttp >=3.7.3,<4
 
-  - name: slack_sdk
-    requirements:
-      host:
-        - pip
-        - python
-        - setuptools
-        - wheel
-      run:
-        - python
-        - {{ pin_subpackage(name, exact=True) }}
-    test:
-      imports:
-        - slack_sdk
-      commands:
-        - pip check
-        - python -c "from importlib.metadata import version; assert(version('{{ name|replace('-', '_') }}')=='{{ version }}')"
+# ModuleNotFoundError: No module named 'tests'
+{% set ignore_tests = " --ignore=tests/test_proxy_env_variable_loader.py" %}
+
+test:
+    source_files:
+      - tests
+    imports:
+      - slack_sdk
+      - slack_sdk.web
+      - slack_sdk.webhook
+      - slack_sdk.signature
+      - slack_sdk.socket_mode
+      - slack_sdk.audit_logs
+      - slack_sdk.scim
+      - slack_sdk.oauth
+      - slack_sdk.models
+      - slack_sdk.rtm
+      - slack_sdk.rtm_v2
+    requires:
+      - pip
+      - pytest >=7.0.1,<9
+    commands:
+      - pip check
+      - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+      - pytest -v {{ ignore_tests }} tests
 
 about:
   home: https://slack.dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,7 @@ outputs:
       requires:
         - pip
         - pytest >=7.0.1,<9
+        - aiohttp >=3.7.3,<4
       commands:
         - pip check
         - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,12 +56,19 @@ outputs:
     requirements:
       host:
         - python
+        - setuptools
+        - wheel
       run:
         - python
         - {{ pin_subpackage(name, min_pin='x.x.x', max_pin='x.x.x') }}
     test:
       imports:
         - slack_sdk
+      requires:
+        - pip
+      commands:
+        - pip check
+        - python -c "from importlib.metadata import version; assert(version('{{ name|replace('_', '-') }}')=='{{ version }}')"        
 
 about:
   home: https://slack.dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,55 +1,67 @@
-{% set name = "slack-sdk" %}
+{% set name = "slack_sdk" %}
 {% set version = "3.36.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name|lower }}-split
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/slack_sdk-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 8586022bdbdf9f8f8d32f394540436c53b1e7c8da9d21e1eab4560ba70cfcffa
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<36]
 
-requirements:
-  host:
-    - pip
-    - python
-    - setuptools
-    - wheel
-  run:
-    - python
-    # The old RTM API (slack_sdk.rtm) has a dependency on aiohttp
-    - aiohttp >=3.7.3,<4
+outputs:
+  - name: {{ name }}
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [not win]
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+        - wheel
+      run:
+        - python
+        # The old RTM API (slack_sdk.rtm) has a dependency on aiohttp
+        - aiohttp >=3.7.3,<4
+    test:
+      source_files:
+        - tests
+      imports:
+        - slack_sdk
+        - slack_sdk.web
+        - slack_sdk.webhook
+        - slack_sdk.signature
+        - slack_sdk.socket_mode
+        - slack_sdk.audit_logs
+        - slack_sdk.scim
+        - slack_sdk.oauth
+        - slack_sdk.models
+        - slack_sdk.rtm
+        - slack_sdk.rtm_v2
+      requires:
+        - pip
+        - pytest >=7.0.1,<9
+      commands:
+        - pip check
+        - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+        # ModuleNotFoundError: No module named 'tests'
+        {% set ignore_tests = " --ignore=tests/test_proxy_env_variable_loader.py" %}
+        - pytest -v {{ ignore_tests }} tests
 
-# ModuleNotFoundError: No module named 'tests'
-{% set ignore_tests = " --ignore=tests/test_proxy_env_variable_loader.py" %}
-
-test:
-    source_files:
-      - tests
-    imports:
-      - slack_sdk
-      - slack_sdk.web
-      - slack_sdk.webhook
-      - slack_sdk.signature
-      - slack_sdk.socket_mode
-      - slack_sdk.audit_logs
-      - slack_sdk.scim
-      - slack_sdk.oauth
-      - slack_sdk.models
-      - slack_sdk.rtm
-      - slack_sdk.rtm_v2
-    requires:
-      - pip
-      - pytest >=7.0.1,<9
-    commands:
-      - pip check
-      - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-      - pytest -v {{ ignore_tests }} tests
+  - name: slack-sdk
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage(name, min_pin='x.x.x', max_pin='x.x.x') }}
+    test:
+      imports:
+        - slack_sdk
 
 about:
   home: https://slack.dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,15 @@ outputs:
         - wheel
       run:
         - python
-        # The old RTM API (slack_sdk.rtm) has a dependency on aiohttp
+      run_constrained:
+        # https://github.com/slackapi/python-slack-sdk/blob/v3.36.0/requirements/optional.txt
+        # https://github.com/slackapi/python-slack-sdk/blob/v3.36.0/slack_sdk/aiohttp_version_checker.py#L21
         - aiohttp >=3.7.3,<4
+        - aiodns >1.0
+        - boto3 <=2
+        - sqlalchemy >=1.4,<3
+        - websockets >=9.1,<16
+        - websocket-client >=1,<2
     test:
       source_files:
         - tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ outputs:
   - name: slack_sdk
     requirements:
       host:
+        - pip
         - python
         - setuptools
         - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,22 @@
 {% set name = "slack-sdk" %}
-{% set version = "3.19.5" %}
+{% set version = "3.36.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/slack_sdk-{{ version }}.tar.gz
-  sha256: 47fb4af596243fe6585a92f3034de21eb2104a55cc9fd59a92ef3af17cf9ddd8
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/slack_sdk-{{ version }}.tar.gz
+  sha256: 8586022bdbdf9f8f8d32f394540436c53b1e7c8da9d21e1eab4560ba70cfcffa
 
 build:
   number: 0
+  skip: True  # [py<36]
 
 outputs:
   - name: slack-sdk
-    build:
-      skip: True  # [py<36]
-      script: python -m pip install . -vv --no-deps
+    script: build_base.bat  # [win]
+    script: build_base.sh   # [not win]
     requirements:
       host:
         - pip
@@ -26,6 +26,8 @@ outputs:
       run:
         - python
     test:
+      source_files:
+        - tests
       imports:
         - slack_sdk
         - slack_sdk.web
@@ -40,14 +42,15 @@ outputs:
         - slack_sdk.rtm_v2
       requires:
         - pip
+        - pytest
         # The old RTM API (slack_sdk.rtm) has a dependency on aiohttp
         - aiohttp >=3.7.3,<4
       commands:
         - pip check
+        - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+        - pytest tests
 
   - name: slack_sdk
-    build:
-      noarch: python
     requirements:
       host:
         - pip
@@ -60,9 +63,12 @@ outputs:
     test:
       imports:
         - slack_sdk
+      commands:
+        - pip check
+        - python -c "from importlib.metadata import version; assert(version('{{ name|replace('-', '_') }}')=='{{ version }}')"
 
 about:
-  home: https://slack.dev/
+  home: https://slack.dev
   summary: The Slack API Platform SDK for Python
   description: |
     The Slack platform offers several APIs to build apps. 
@@ -75,7 +81,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   dev_url: https://github.com/slackapi/python-slack-sdk
-  doc_url: https://slack.dev/python-slack-sdk/
+  doc_url: https://slack.dev/python-slack-sdk
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
slack-sdk 3.36.0 

**Destination channel:** Defaults

### Links

- [PKG-8159]
- dev_url:        https://github.com/slackapi/python-slack-sdk/tree/v3.36.0
- conda_forge:    https://github.com/conda-forge/slack-sdk-feedstock
- pypi:           https://pypi.org/project/slack-sdk/3.36.0
- pypi inspector: https://inspector.pypi.io/project/slack-sdk/3.36.0

### Explanation of changes:

- new version number


[PKG-8159]: https://anaconda.atlassian.net/browse/PKG-8159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ