### PR TITLE
slack-sdk 3.39.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "slack-sdk" %}
-{% set version = "3.36.0" %}
+{% set version = "3.39.0" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 8586022bdbdf9f8f8d32f394540436c53b1e7c8da9d21e1eab4560ba70cfcffa
+  sha256: 6a56be10dc155c436ff658c6b776e1c082e29eae6a771fccf8b0a235822bbcb1
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: True  # [py<37]
 
 outputs:
   - name: slack-sdk
@@ -22,7 +22,6 @@ outputs:
         - pip
         - python
         - setuptools
-        - wheel
       run:
         - python
       run_constrained:
@@ -53,6 +52,7 @@ outputs:
         - pip
         - pytest >=7.0.1,<9
         - aiohttp >=3.7.3,<4
+        - pytest-asyncio <2
       commands:
         - pip check
         - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
@@ -66,7 +66,6 @@ outputs:
         - pip
         - python
         - setuptools
-        - wheel
       run:
         - python
         - {{ pin_subpackage(name, min_pin='x.x.x', max_pin='x.x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,10 @@ outputs:
         # ModuleNotFoundError: No module named 'tests'
         {% set ignore_tests = " --ignore=tests/test_proxy_env_variable_loader.py" %}
         - pytest -v {{ ignore_tests }} tests
+        # test_rtm_client_never_generate_huge_number_of_event_loops is not supported in Python 3.14+:
+        # RuntimeError: There is no current event loop in thread 'MainThread'.
+        - pytest --pyargs slack_sdk {{ ignore_tests }} -v  # [py < 314]
+        - pytest --pyargs slack_sdk {{ ignore_tests }} -v -k "not test_rtm_client_never_generate_huge_number_of_event_loops"  # [py>=314]
 
   - name: slack_sdk
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ outputs:
         - pytest -v {{ ignore_tests }} tests
         # test_rtm_client_never_generate_huge_number_of_event_loops is not supported in Python 3.14+:
         # RuntimeError: There is no current event loop in thread 'MainThread'.
-        - pytest tests {{ ignore_tests }} -v  # [py < 314]
+        - pytest tests {{ ignore_tests }} -v  # [py<314]
         - pytest tests {{ ignore_tests }} -v -k "not test_rtm_client_never_generate_huge_number_of_event_loops"  # [py>=314]
 
   - name: slack_sdk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,6 @@ outputs:
         - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
         # ModuleNotFoundError: No module named 'tests'
         {% set ignore_tests = " --ignore=tests/test_proxy_env_variable_loader.py" %}
-        - pytest -v {{ ignore_tests }} tests
         # test_rtm_client_never_generate_huge_number_of_event_loops is not supported in Python 3.14+:
         # RuntimeError: There is no current event loop in thread 'MainThread'.
         - pytest tests {{ ignore_tests }} -v  # [py<314]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,8 +61,8 @@ outputs:
         - pytest -v {{ ignore_tests }} tests
         # test_rtm_client_never_generate_huge_number_of_event_loops is not supported in Python 3.14+:
         # RuntimeError: There is no current event loop in thread 'MainThread'.
-        - pytest --pyargs slack_sdk {{ ignore_tests }} -v  # [py < 314]
-        - pytest --pyargs slack_sdk {{ ignore_tests }} -v -k "not test_rtm_client_never_generate_huge_number_of_event_loops"  # [py>=314]
+        - pytest tests {{ ignore_tests }} -v  # [py < 314]
+        - pytest tests {{ ignore_tests }} -v -k "not test_rtm_client_never_generate_huge_number_of_event_loops"  # [py>=314]
 
   - name: slack_sdk
     requirements:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-10918](https://anaconda.atlassian.net/browse/PKG-10918) 
- [Upstream repository](https://github.com/slackapi/python-slack-sdk/blob/v3.39.0/pyproject.toml)

### Explanation of changes:

- Skip py<37
- Remove wheel
- Add pytest-asyncio to tests
- Skip `test_rtm_client_never_generate_huge_number_of_event_loops` because Python 3.14 changed asyncio event loop behavior - `asyncio.get_event_loop()` now raises `RuntimeError` instead of auto-creating loops, breaking legacy code patterns that relied on implicit loop creation.

### Notes:

- Add py314 support in abs.yaml

[PKG-10918]: https://anaconda.atlassian.net/browse/PKG-10918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ